### PR TITLE
Add much better hover effect to content links

### DIFF
--- a/overrides/assets/stylesheets/home.css
+++ b/overrides/assets/stylesheets/home.css
@@ -27,6 +27,10 @@
 	width: 100%
 }
 
+.md-typeset a:hover {
+  color: #828dd9 !important;
+}
+
 
 .md-typeset .mdx-insiders {
 	color: #e91e63


### PR DESCRIPTION
At first I thought there wasn't one currently, but after looking carefully it seems to be *very* slight to the point of being unnoticable.

The hover effect is using a custom hex due to none of the variables having a colour that was easy to see.