### PR TITLE
Implement spellcheck and fix existing typos

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,0 +1,17 @@
+name: "Spell Check"
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  check:
+    # run on all push events or on PR syncs not from the same repo
+    if: github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Spell check
+        uses: crate-ci/typos@v1.24.6

--- a/docs/features/commands.md
+++ b/docs/features/commands.md
@@ -102,7 +102,7 @@ The `time` option can be any number of minutes, hours, days, or weeks - e.g. `5d
 
 |                               Name                               |                                          Description                                           | Example |
 | :--------------------------------------------------------------: | :--------------------------------------------------------------------------------------------: | :-----: |
-| :material-comment-text:{ .tip title="Autocompleted" } `category` |             Close all tickets in hte specified category (can be used with 'time')              |   N/A   |
+| :material-comment-text:{ .tip title="Autocompleted" } `category` |             Close all tickets in the specified category (can be used with 'time')              |   N/A   |
 |                             `reason`                             |                         The reason why the ticket(s) should be closed                          |   N/A   |
 |  :material-comment-text:{ .tip title="Autocompleted" } `ticket`  |                                      The ticket to close                                       |   N/A   |
 |                              `time`                              | Close all tickets that have been inactive for the specified time (can be used with 'category') |  `1w`   |

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -57,10 +57,10 @@ This flowchart shows the different pathways that can be taken to create a ticket
 flowchart TB
     A1(["➡️ /new command"]) ----> B
     A2(["➡️ Panel button/menu"]) ----> D
-    A3(["➡️ Messsage:Create command"]) ---> B
+    A3(["➡️ Message:Create command"]) ---> B
     %% fa:fa-arrow-right-long
     A4(["➡️ User:Create command (staff)"]) -...->|"Staff interaction"| B
-    A5(["➡️ DM (message is topic)"]) --> AA{Mulitple servers?}
+    A5(["➡️ DM (message is topic)"]) --> AA{Multiple servers?}
     AA -->|Yes| AA1[/"❓ Select server with menu"/] ---> B
     AA -->|No| B
     B{Multiple categories?}

--- a/docs/self-hosting/configuration.md
+++ b/docs/self-hosting/configuration.md
@@ -25,7 +25,7 @@ The installation guides also explain where to find most of the environment varia
 	DB_CONNECTION_URL="mysql://bots:VerySecurePassword123@localhost/tickets0"
 	DB_PROVIDER=mysql
 	DISCORD_SECRET=rUpDU2T8K4ZXie8kdpzYsMTLbUhvmBRd
-	DISCORD_TOKEN=ODcwOTg1TY0NjI0NODI2Mzc0.DNg0e0.UYVof7V1v0kRA0HHtGwXKA3UERxwANAZhQiA
+	DISCORD_TOKEN=ODcwOTg1TY0NjI0NODI2Mzc0.DNg0e0.UYVof7V1v0kRA0HHtGwXKA3URxwANAZhQiA
 	ENCRYPTION_KEY=445940dbed49eff55df56dd646fa1cb4b686df4cb9ac004a
 	HTTP_EXTERNAL=https://tickets.example.com
 	HTTP_HOST=0.0.0.0

--- a/docs/self-hosting/installation/docker.md
+++ b/docs/self-hosting/installation/docker.md
@@ -231,7 +231,7 @@ docker run -itd \
   -e DB_CONNECTION_URL="mysql://bots:VerySecurePassword123@localhost/tickets0" \
   -e DB_PROVIDER="mysql" \
   -e DISCORD_SECRET="rUpDU2T8K4ZXie8kdpzYsMTLbUhvmBRd" \
-  -e DISCORD_TOKEN="ODcwOTg1TY0NjI0NODI2Mzc0.DNg0e0.UYVof7V1v0kRA0HHtGwXKA3UERxwANAZhQiA" \
+  -e DISCORD_TOKEN="ODcwOTg1TY0NjI0NODI2Mzc0.DNg0e0.UYVof7V1v0kRA0HHtGwXKA3URxwANAZhQiA" \
   -e ENCRYPTION_KEY="445940dbed49eff55df56dd646fa1cb4b686df4cb9ac004a" \
   -e HTTP_EXTERNAL="https://tickets.example.com" \
   -e HTTP_TRUST-PROXY="true" \

--- a/docs/self-hosting/reverse-proxy.md
+++ b/docs/self-hosting/reverse-proxy.md
@@ -132,7 +132,7 @@ server {
 This example shows the additions you may need to make to your `docker-compose.yml` file to configure Traefik.
 After installing and configuring Traefik (referring to the documentation linked above), change the highlighted values to match your configuration.
 
-This example shows the configuration you may need to add to the `bot` service & router in [:octicons-arrow-right-24: exemple docker-compose.yml](https://github.com/discord-tickets/bot/blob/main/docker-compose.yml) file.
+This example shows the configuration you may need to add to the `bot` service & router in [:octicons-arrow-right-24: example docker-compose.yml](https://github.com/discord-tickets/bot/blob/main/docker-compose.yml) file.
 Refer to the documentation linked above for more information.
 
 <div class="annotate" markdown>

--- a/docs/self-hosting/updating.md
+++ b/docs/self-hosting/updating.md
@@ -67,7 +67,7 @@ This guide assumes you're using a Bot hosting plan from PebbleHost and not a ded
 
 ![4](https://github.com/discord-tickets/docs/assets/86845749/264cc0fa-a488-4b58-a664-26647921898e)
 
-5) Select the databse you're using from the list
+5) Select the database you're using from the list
 
 ![5](https://github.com/discord-tickets/docs/assets/86845749/88315de1-e3cc-43d7-95dc-54df945852b2)
 

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,12 @@
+# Used by the typos action
+
+[files]
+extend-exclude = [
+    "overrides" # not words
+]
+
+[default]
+locale = "en-gb"
+
+[files]
+extend-exclude = ["*.txt", "*.toml", "*.yaml", "*.yml", "*.js", "*.html", '*.css"]

--- a/typos.toml
+++ b/typos.toml
@@ -2,6 +2,30 @@
 
 [default]
 locale = "en-gb"
+check-filename = true
+extend-ignore-re = [
+
+    # Most usage of these words is in code where the american spelling is used or required
+    "Authorization",
+    "initalize",
+    "mustache"
+    
+]
 
 [files]
-extend-exclude = ["*.txt", "*.toml", "*.yaml", "*.yml", "*.js", "*.html", "*.css", "overrides/"]
+extend-exclude = [
+
+    # Code is primarily written in American English
+    "*.txt", 
+    "*.toml", 
+    "*.yaml", 
+    "*.yml", 
+    "*.js", 
+    "*.html", 
+    "*.css", 
+    "overrides/",
+
+    # Written entirely in American English
+    "LICENSE"
+    
+]

--- a/typos.toml
+++ b/typos.toml
@@ -1,12 +1,7 @@
 # Used by the typos action
 
-[files]
-extend-exclude = [
-    "overrides" # not words
-]
-
 [default]
 locale = "en-gb"
 
 [files]
-extend-exclude = ["*.txt", "*.toml", "*.yaml", "*.yml", "*.js", "*.html", '*.css"]
+extend-exclude = ["*.txt", "*.toml", "*.yaml", "*.yml", "*.js", "*.html", '*.css", "overrides"]

--- a/typos.toml
+++ b/typos.toml
@@ -4,4 +4,4 @@
 locale = "en-gb"
 
 [files]
-extend-exclude = ["*.txt", "*.toml", "*.yaml", "*.yml", "*.js", "*.html", '*.css", "overrides"]
+extend-exclude = ["*.txt", "*.toml", "*.yaml", "*.yml", "*.js", "*.html", "*.css", "overrides/"]

--- a/typos.toml
+++ b/typos.toml
@@ -8,6 +8,7 @@ extend-ignore-re = [
     # Most usage of these words is in code where the american spelling is used or required
     "Authorization",
     "initialize",
+    "mustache",
     "Mustache",
     "color"
     

--- a/typos.toml
+++ b/typos.toml
@@ -7,8 +7,8 @@ extend-ignore-re = [
 
     # Most usage of these words is in code where the american spelling is used or required
     "Authorization",
-    "initalize",
-    "mustache",
+    "initialize",
+    "Mustache",
     "color"
     
 ]

--- a/typos.toml
+++ b/typos.toml
@@ -8,7 +8,8 @@ extend-ignore-re = [
     # Most usage of these words is in code where the american spelling is used or required
     "Authorization",
     "initalize",
-    "mustache"
+    "mustache",
+    "color"
     
 ]
 
@@ -26,6 +27,7 @@ extend-exclude = [
     "overrides/",
 
     # Written entirely in American English
-    "LICENSE"
+    "LICENSE",
+    "docs/terms.md"
     
 ]


### PR DESCRIPTION
Implement a spell check action for all future commits and fix the existing spelling issues (which are all minor anyway)

- Implemented spell check action and a config to clean out code files as they are in American English instead of British English
- Filtered out common words used in code that use American English (initalize, color, etc)
- Filtered out legal documents (repo license and bot terms document, these could maybe be converted to British English later?)
- Fixed all existing typos
- Altered the example discord bot token slightly as they spellcheck mistook it for misspelled words