### PR TITLE
Add CONTRIBUTING.md and improve guidance (plus other changes)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+## Contributing Guide
+
+For simple changes, you can easily create a fork, edit the files you want to change, open a PR, and see the result with the PR deploy preview from the Netlify bot.
+
+> [!CAUTION]
+> The documentation only supports *British* English for written language. [Spell checks](https://github.com/discord-tickets/docs/actions/workflows/spelling-check.yml) will fail if you use other languages or other forms of English. Code, code snippets, config files, etc can be in American English.
+
+> [!TIP]
+> If you are editing tables, please clone the repository locally and edit it with an appropriate IDE (like VS Code) using a markdown formatting extension.
+
+### Local preview
+
+If you want to preview locally, clone the repo and then run `pip install -r requirements.txt` and `mkdocs serve`.
+
+If you choose to run a local preview, the site will not look the same as the production version, this is because it is built with a specific version of the Insiders edition of the theme, which has additional features and a different config. 
+
+This is normal as the v4 documentation uses a newer version of MkDocs that is configured differently.

--- a/README.md
+++ b/README.md
@@ -10,17 +10,7 @@ You can view the latest build of the site [here](https://discordtickets.app/).
 
 ## Contributing
 
-For simple changes, you can easily create a fork, edit the files you want to change, open a PR, and see the result with the PR deploy preview from the Netlify bot.
-
-**If you are editing tables**, please clone the repository locally, edit with an appropriate IDE (such as VS Code) and use a markdown formatting extension.
-
-### Local preview
-
-If you want to preview locally, clone the repo and then run `pip install -r requirements.txt` and `mkdocs serve`.
-
-If you choose to run a local preview, the site will not look the same as the production version,
-because it is built with a specific version of the Insiders edition of the theme, which has additional features and a different config.
-This is normal as the v4 documentation uses a newer version of MkDocs that is configured differently.
+See [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 ## Spontaneous Puffin Image
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,6 @@
 This is the source for the Discord Tickets v4 documentation (and marketing) website.
 You can view the latest build of the site [here](https://discordtickets.app/).
 
-> **Note**
-> For the v3 documentation, visit [v3.discordtickets.app](https://v3.discordtickets.app) or look at the `v3.1` branch.
-
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md)


### PR DESCRIPTION
This adds a new CONTRIBUTING.md guide with a link to it that has improved guidance on how to contribute to the documentation and things to watch out for. It also does some more general housekeeping like removing the dead link to the v3 docs.

I might change the TIP and CAUTION labels used in the guidance but I want to gauge feedback first