### PR TITLE
Update generic.md for selfhost pterodactyl

### DIFF
--- a/docs/self-hosting/index.md
+++ b/docs/self-hosting/index.md
@@ -9,7 +9,7 @@
 You can view the supported installation methods on the next page <span class="tip">(:material-fire:{ title="Tip" } you can press ++n++ or ++gt++)</span>.
 Regardless of the installation method you choose, the bot requires:
 
-- **Node.js v18** or higher (with npm, pnpm, or yarn)
+- **Node.js v20** or higher (with npm, pnpm, or yarn)
 - a forwarded (not firewalled) port
 - at least **150MB RAM**
 - at least **1GB disk** space (at least 100MB for the database if archiving)

--- a/docs/self-hosting/installation/pterodactyl/generic.md
+++ b/docs/self-hosting/installation/pterodactyl/generic.md
@@ -20,10 +20,10 @@ Note that although the bot may use under 100-150MB of RAM (depending on the serv
 
 ## Installation
 
-Start by creating a new Node.js v18 server.
+Start by creating a new Node.js v20+ server.
 
 1. Set the git repository to `https://github.com/discord-tickets/bot`
-2. Set the branch to the latest tag, e.g. `v4.0.0`.
+2. Set the branch to the latest tag, e.g. `v4.0.35`.
    You can find the latest tag at the top right corner of this page or [here](https://github.com/discord-tickets/bot/releases/latest).
 3. Enable auto-updating so the startup script will download the code for you
 4. Change the file to `src/index.js`


### PR DESCRIPTION
4.0.35 (aka main) needs node.js 20+ because when following the install guide it failed.

fast-jwt@5.0.5 requires node.js 20 or higher.